### PR TITLE
Static binary busybox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM quay.io/nordstrom/baseimage-ubuntu:16.04
+FROM prom/busybox:latest
 MAINTAINER Innovation Platform Team "invcldtm@nordstrom.com"
 
-USER root
 COPY prometheusRuleLoader /bin/prometheusRuleLoader
 RUN chmod 755 /bin/prometheusRuleLoader
-USER ubuntu
 
 ENTRYPOINT	["/bin/prometheusRuleLoader"]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ container_release := 2.3
 $(app_name): *.go
 	docker run --rm \
 	  -e CGO_ENABLED=true \
+	  -e LDFLAGS='-extldflags "-static"' \
+	  -e COMPRESS_BINARY=true \
 	  -e OUTPUT=$(app_name) \
 	  -v $(shell pwd):/src:rw \
 	  centurylink/golang-builder


### PR DESCRIPTION
This PR builds the prometheusruleloader tool statically, then packages it into a slim, busybox-based docker image.

As a consequence, the docker image size (displayed by `docker images | grep prometheusruleloader`) goes from 126Mb to 11.4Mb.

Please let me know if there is any known objection to statically linking the binary.
