### PR TITLE
Fixes #12

### DIFF
--- a/main.go
+++ b/main.go
@@ -264,12 +264,10 @@ func (c *Controller) extractValues(fallbackNameStub string, data map[string]stri
 			} else {
 				mrg.Values = append(mrg.Values, myrulegroups)
 				myerrors = append(myerrors,err)
-				mrg.Values = append(mrg.Values, myrulegroups)
 			}
 		} else {
 			mrg.Values = append(mrg.Values, myrulegroups)
 			myerrors = append(myerrors,err)
-			mrg.Values = append(mrg.Values, myrulegroups)
 		}
 	}
 


### PR DESCRIPTION
Fix duplicate rules when Configmap value is RuleGroups or RuleGroup

My go environment has issues with `dlv test` with `godeps` vendoring so I am unable to run tests. But from my testing this fixes the problem.