### PR TITLE
temp fix for deleting whole configmaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 app_name := prometheusRuleLoader
 container_name := prometheusruleloader
 container_registry := gitlab-registry.nordstrom.com/k8s/platform-bootstrap
-container_release := 5.0
+container_release := 5.1
 
 .PHONY: build tag/image push/image clean
 


### PR DESCRIPTION
Fixes a bug where the rule config would not be rebuilt if a whole configmap was deleted. This is a temporary fix that forces a rebuild if the configmap was deleted. I'm going to rework the early-out cache `haveConfigMapsChanged` since it won't currently catch a deleted configmap.